### PR TITLE
#168818198 fix the bug to start the server on heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "scripts": {
         "test": "mocha --require @babel/register server/tests/ --exit",
-        "start": "node ./dist/index",
+        "start": "node ./dist/app",
         "dev": "nodemon --exec babel-node server/app",
         "build": "babel server -d dist",
         "lint": "eslint server"


### PR DESCRIPTION
### What does this PR do?
This pull request sets up the right command to start server on horeku in order to build and deploy my app online

### Description of Task to be completed?
The task done here is editing package.json script object on `start` to be `node ./dist/app` instead of `node ./dist/app`.

### How should this be manually tested?
Clone or download the develop branch to your local machine and you can see the changes.

### What are the relevant pivotal tracker stories?
[Finishes #168818198]